### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/tools/ef-migrate/main.go
+++ b/tools/ef-migrate/main.go
@@ -264,7 +264,8 @@ func showStatus(manager *migrations.EFMigrationManager, config CLIConfig) {
 		log.Fatal("❌ Failed to get migration status:", err)
 	}
 
-	fmt.Printf("Database: %s\n", extractDBName(config.ConnectionString))
+	sanitizedConnectionString := sanitizeConnectionString(config.ConnectionString)
+	fmt.Printf("Database: %s\n", extractDBName(sanitizedConnectionString))
 	fmt.Printf("Applied:  %d migrations\n", len(history.Applied))
 	fmt.Printf("Pending:  %d migrations\n", len(history.Pending))
 	fmt.Printf("Failed:   %d migrations\n", len(history.Failed))
@@ -441,6 +442,11 @@ func buildPostgreSQLConnectionString(config CLIConfig) string {
 	
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
 		config.User, config.Password, host, port, config.Database, sslmode)
+}
+
+func sanitizeConnectionString(connectionString string) string {
+	re := regexp.MustCompile(`(postgres://.*:)(.*)(@.*)`)
+	return re.ReplaceAllString(connectionString, "${1}*****${3}")
 }
 
 func printUsage() {


### PR DESCRIPTION
Potential fix for [https://github.com/lamboktulussimamora/gra/security/code-scanning/1](https://github.com/lamboktulussimamora/gra/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive information, such as the password in the connection string, is not logged. This can be achieved by sanitizing the connection string to remove or obfuscate sensitive parts (e.g., replacing the password with a placeholder) before passing it to `extractDBName` or logging it. Specifically:

1. Modify the `buildPostgreSQLConnectionString` function to include a helper function that sanitizes the connection string by replacing the password with a placeholder (e.g., `*****`).
2. Use the sanitized connection string in the `extractDBName` function and any logging calls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
