### PR TITLE
Rate limiting: trusted-proxy client IP

### DIFF
--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -12,6 +12,7 @@ Middleware functions provide a way to execute code before or after request handl
   - [Secure Headers](#secure-headers)
   - [Authentication](#authentication)
   - [Cache](#cache)
+    - [Rate Limiting](#rate-limiting)
 - [Creating Custom Middleware](#creating-custom-middleware)
 
 ## Using Middleware
@@ -218,51 +219,80 @@ config := middleware.CacheConfig{
 r.Use(middleware.CacheWithConfig(config))
 ```
 
-## Creating Custom Middleware
+### Rate Limiting
 
-You can create custom middleware by returning a `gra.HandlerFunc`:
+Rate limiting helps prevent abuse by limiting requests per client IP.
 
 ```go
-func RateLimiter(rps int, burst int) gra.HandlerFunc {
-    // Create a rate limiter
-    limiter := rate.NewLimiter(rate.Limit(rps), burst)
-    
-    // Return the middleware handler
-    return func(c *gra.Context) {
-        // Check if the request can proceed
-        if !limiter.Allow() {
-            c.Error(http.StatusTooManyRequests, "Too many requests")
-            return
+// Allow up to 100 requests per 60 seconds per client IP
+r.Use(middleware.RateLimit(100, 60))
+```
+
+#### Behind Reverse Proxies
+
+If you run behind a reverse proxy/load balancer, the real client IP is typically
+provided via `X-Forwarded-For` or `X-Real-IP`.
+
+For security, you must only trust these headers when the immediate peer
+(`RemoteAddr`) is a trusted proxy.
+
+```go
+trusted, err := middleware.ParseTrustedProxies([]string{
+    "127.0.0.1/32", // local reverse proxy
+    "10.0.0.0/8",   // internal load balancer network
+})
+if err != nil {
+    panic(err)
+}
+
+cfg := middleware.RateLimiterConfig{
+    Store:  middleware.NewInMemoryStore(),
+    Limit:  100,
+    Window: 60,
+    KeyFunc: func(c *gra.Context) string {
+        return middleware.ClientIPFromContext(c, trusted)
+    },
+}
+
+r.Use(middleware.RateLimitWithConfig(cfg))
+```
+
+## Creating Custom Middleware
+
+You can create custom middleware by returning a `gra.Middleware`:
+
+```go
+func RequireHeader(name string) gra.Middleware {
+    return func(next gra.HandlerFunc) gra.HandlerFunc {
+        return func(c *gra.Context) {
+            if c.Request.Header.Get(name) == "" {
+                c.Error(http.StatusBadRequest, name+" header is required")
+                return
+            }
+            next(c)
         }
-        
-        // Call the next handler
-        c.Next()
     }
 }
 
-// Use the custom middleware
-r.Use(RateLimiter(10, 30))
+r.Use(RequireHeader("X-Request-ID"))
 ```
 
 ### Middleware Best Practices
 
-1. **Call `c.Next()` to continue** the request chain (unless you want to short-circuit)
-2. **Check `c.IsAborted()`** before executing code after `c.Next()`
-3. **Use `c.Set()`** to share data between middleware and handlers
+1. **Call `next(c)`** to continue the request chain (unless you want to short-circuit)
+2. **Validate inputs early** and return explicit errors
+3. **Use `c.WithValue(...)`** to attach request-scoped data
 4. **Handle errors properly** and set appropriate status codes
 5. **Keep middleware focused** on a single responsibility
 6. **Order middleware correctly** (e.g., Recovery should be first)
 
 ```go
-func MyMiddleware() gra.HandlerFunc {
-    return func(c *gra.Context) {
-        // Code executed before the request
-        
-        c.Next() // Call the next handler
-        
-        // Code executed after the request (if not aborted)
-        if !c.IsAborted() {
-            // Post-processing
+func MyMiddleware() gra.Middleware {
+    return func(next gra.HandlerFunc) gra.HandlerFunc {
+        return func(c *gra.Context) {
+            // Code executed before the request
+            next(c)
+            // Code executed after the request
         }
     }
 }

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -1,0 +1,181 @@
+package middleware
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/lamboktulussimamora/gra/context"
+)
+
+// ParseTrustedProxies parses a list of trusted proxy entries (CIDR blocks or plain IPs)
+// into a slice of *net.IPNet.
+func ParseTrustedProxies(entries []string) ([]*net.IPNet, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	nets := make([]*net.IPNet, 0, len(entries))
+	for _, raw := range entries {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			continue
+		}
+
+		if strings.Contains(s, "/") {
+			_, ipNet, err := net.ParseCIDR(s)
+			if err != nil {
+				return nil, fmt.Errorf("invalid trusted proxy CIDR %q: %w", s, err)
+			}
+			nets = append(nets, ipNet)
+			continue
+		}
+
+		ip := net.ParseIP(s)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid trusted proxy IP %q", s)
+		}
+		nets = append(nets, ipToIPNet(ip))
+	}
+
+	return nets, nil
+}
+
+func ipToIPNet(ip net.IP) *net.IPNet {
+	if ip4 := ip.To4(); ip4 != nil {
+		return &net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)}
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+}
+
+func isTrustedProxy(ip net.IP, trusted []*net.IPNet) bool {
+	if ip == nil || len(trusted) == 0 {
+		return false
+	}
+	for _, n := range trusted {
+		if n != nil && n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ClientIPFromContext returns the best-effort client IP address for a request.
+//
+// Security note: proxy headers are only consulted when the immediate peer (RemoteAddr)
+// is in a trusted proxy range.
+func ClientIPFromContext(c *context.Context, trustedProxies []*net.IPNet) string {
+	if c == nil || c.Request == nil {
+		return ""
+	}
+	return ClientIPFromRequest(c.Request, trustedProxies)
+}
+
+// ClientIPFromRequest returns the best-effort client IP address.
+//
+// If RemoteAddr is not a trusted proxy, it is returned (with any port stripped).
+// If RemoteAddr is trusted, X-Forwarded-For is parsed and the last untrusted IP in
+// the chain is returned. If unavailable, X-Real-IP is used as a fallback.
+func ClientIPFromRequest(r *http.Request, trustedProxies []*net.IPNet) string {
+	if r == nil {
+		return ""
+	}
+
+	remoteHost := stripPort(r.RemoteAddr)
+	remoteIP := net.ParseIP(remoteHost)
+	if remoteIP == nil {
+		// If we can't parse it, keep the original host string (minus port if any).
+		return remoteHost
+	}
+
+	if !isTrustedProxy(remoteIP, trustedProxies) {
+		return remoteIP.String()
+	}
+
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if ip := clientIPFromXFF(xff, trustedProxies); ip != nil {
+			return ip.String()
+		}
+	}
+
+	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
+		if ip := parseIPLoose(xri); ip != nil {
+			return ip.String()
+		}
+	}
+
+	return remoteIP.String()
+}
+
+func stripPort(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	// Handle bracketed IPv6 without a port: "[2001:db8::1]".
+	if strings.HasPrefix(addr, "[") {
+		if end := strings.Index(addr, "]"); end > 0 {
+			return addr[1:end]
+		}
+	}
+	return addr
+}
+
+func clientIPFromXFF(xff string, trustedProxies []*net.IPNet) net.IP {
+	parts := strings.Split(xff, ",")
+	ips := make([]net.IP, 0, len(parts))
+	for _, p := range parts {
+		ip := parseIPLoose(p)
+		if ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+	if len(ips) == 0 {
+		return nil
+	}
+
+	// Walk right-to-left: drop trusted proxy hops; return the first untrusted IP.
+	for i := len(ips) - 1; i >= 0; i-- {
+		if !isTrustedProxy(ips[i], trustedProxies) {
+			return ips[i]
+		}
+	}
+
+	// All hops are trusted; best guess is left-most (original client).
+	return ips[0]
+}
+
+func parseIPLoose(raw string) net.IP {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil
+	}
+	// Trim optional quotes.
+	s = strings.Trim(s, "\"")
+
+	// Handle bracketed IPv6: "[2001:db8::1]:1234" or "[2001:db8::1]".
+	if strings.HasPrefix(s, "[") {
+		if end := strings.Index(s, "]"); end > 0 {
+			inner := s[1:end]
+			if ip := net.ParseIP(inner); ip != nil {
+				return ip
+			}
+		}
+	}
+
+	// Try as plain IP first (covers unbracketed IPv6).
+	if ip := net.ParseIP(s); ip != nil {
+		return ip
+	}
+
+	// Try to strip port from IPv4/host:port.
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		return net.ParseIP(host)
+	}
+
+	return nil
+}

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIPFromRequest_IgnoresHeadersWhenPeerNotTrusted(t *testing.T) {
+	trusted, err := ParseTrustedProxies([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies error: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "203.0.113.10:1234"
+	r.Header.Set("X-Forwarded-For", "198.51.100.77")
+	r.Header.Set("X-Real-IP", "198.51.100.88")
+
+	if got := ClientIPFromRequest(r, trusted); got != "203.0.113.10" {
+		t.Fatalf("expected remote IP when peer is untrusted, got %q", got)
+	}
+}
+
+func TestClientIPFromRequest_UsesXFFWhenPeerTrusted(t *testing.T) {
+	trusted, err := ParseTrustedProxies([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies error: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:2222"
+	r.Header.Set("X-Forwarded-For", "198.51.100.77, 10.0.0.1")
+
+	if got := ClientIPFromRequest(r, trusted); got != "198.51.100.77" {
+		t.Fatalf("expected client IP from XFF, got %q", got)
+	}
+}
+
+func TestClientIPFromRequest_XFFStopsAtFirstUntrustedFromRight(t *testing.T) {
+	trusted, err := ParseTrustedProxies([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies error: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:2222"
+	r.Header.Set("X-Forwarded-For", "198.51.100.77, 192.0.2.33, 10.0.0.1")
+
+	if got := ClientIPFromRequest(r, trusted); got != "192.0.2.33" {
+		t.Fatalf("expected first untrusted hop from right, got %q", got)
+	}
+}
+
+func TestClientIPFromRequest_UsesXRealIPFallbackWhenPeerTrusted(t *testing.T) {
+	trusted, err := ParseTrustedProxies([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies error: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:2222"
+	r.Header.Set("X-Real-IP", "198.51.100.88")
+
+	if got := ClientIPFromRequest(r, trusted); got != "198.51.100.88" {
+		t.Fatalf("expected client IP from X-Real-IP, got %q", got)
+	}
+}
+
+func TestClientIPFromRequest_IPv6XFF(t *testing.T) {
+	trusted, err := ParseTrustedProxies([]string{"2001:db8::/32"})
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies error: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "[2001:db8::1]:2222"
+	r.Header.Set("X-Forwarded-For", "2001:db8::2")
+
+	if got := ClientIPFromRequest(r, trusted); got != "2001:db8::2" {
+		t.Fatalf("expected IPv6 client IP from XFF, got %q", got)
+	}
+}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,7 +4,6 @@ package middleware
 import (
 	"crypto/rand"
 	"fmt"
-	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -307,12 +306,10 @@ func RateLimit(limit int, windowSeconds int) router.Middleware {
 		Limit:  limit,
 		Window: windowSeconds,
 		KeyFunc: func(c *context.Context) string {
-			// Default to IP-based rate limiting
-			remote := c.Request.RemoteAddr
-			if host, _, err := net.SplitHostPort(remote); err == nil {
-				return host
-			}
-			return remote
+			// Default to remote IP-based rate limiting.
+			// Proxy headers are ignored unless the caller opts in by providing
+			// trusted proxies via ClientIPFromContext/ClientIPFromRequest.
+			return ClientIPFromContext(c, nil)
 		},
 		ErrorMessage: "Rate limit exceeded. Try again later.",
 	}


### PR DESCRIPTION
Adds safe client IP extraction gated by trusted proxies and documents how to configure rate limiting behind reverse proxies.\n\n- New helpers: ParseTrustedProxies, ClientIPFromRequest/Context\n- RateLimit default uses remote address (no proxy headers unless trusted)\n- Tests for spoofing, proxy chains, IPv6\n- Docs updated with reverse-proxy example and corrected middleware pattern