### PR TITLE
ORM hardening: context-aware SaveChanges + quieter migrations

### DIFF
--- a/orm/dbcontext/db_context.go
+++ b/orm/dbcontext/db_context.go
@@ -2,6 +2,7 @@
 package dbcontext
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -19,17 +20,42 @@ const (
 
 // detectDatabaseDriver detects the database driver type
 func detectDatabaseDriver(db *sql.DB) string {
+	// Use QueryRow to avoid leaking *sql.Rows.
+	var i int
+	var s string
+
 	// Test queries to detect database type
-	if _, err := db.Query("SELECT 1::integer"); err == nil {
+	if err := db.QueryRow("SELECT 1::integer").Scan(&i); err == nil {
 		return driverPostgres
 	}
-	if _, err := db.Query("SELECT sqlite_version()"); err == nil {
+	if err := db.QueryRow("SELECT sqlite_version()").Scan(&s); err == nil {
 		return driverSQLite
 	}
-	if _, err := db.Query("SELECT VERSION()"); err == nil {
+	if err := db.QueryRow("SELECT VERSION()").Scan(&s); err == nil {
 		return driverMySQL
 	}
 	// Default to sqlite3 if detection fails
+	return driverSQLite
+}
+
+func detectTxDriver(tx *sql.Tx) string {
+	if tx == nil {
+		return driverSQLite
+	}
+
+	var i int
+	var s string
+
+	if err := tx.QueryRow("SELECT 1::integer").Scan(&i); err == nil {
+		return driverPostgres
+	}
+	if err := tx.QueryRow("SELECT sqlite_version()").Scan(&s); err == nil {
+		return driverSQLite
+	}
+	if err := tx.QueryRow("SELECT VERSION()").Scan(&s); err == nil {
+		return driverMySQL
+	}
+
 	return driverSQLite
 }
 
@@ -134,6 +160,26 @@ func (d *Database) Begin() (*sql.Tx, error) {
 	return d.db.Begin()
 }
 
+// BeginTx starts a new transaction with context.
+func (d *Database) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return d.db.BeginTx(ctx, opts)
+}
+
+// ExecContext executes a query without returning any rows.
+func (d *Database) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return d.db.ExecContext(ctx, query, args...)
+}
+
+// QueryContext executes a query that returns rows.
+func (d *Database) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return d.db.QueryContext(ctx, query, args...)
+}
+
+// QueryRowContext executes a query that is expected to return at most one row.
+func (d *Database) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return d.db.QueryRowContext(ctx, query, args...)
+}
+
 // EnhancedDbContext provides Entity Framework Core-like functionality
 type EnhancedDbContext struct {
 	db            *sql.DB
@@ -173,14 +219,31 @@ func NewEnhancedDbContextWithDB(db *sql.DB) *EnhancedDbContext {
 
 // NewEnhancedDbContextWithTx creates a new enhanced database context with transaction
 func NewEnhancedDbContextWithTx(tx *sql.Tx) *EnhancedDbContext {
-	// Note: for transactions, we can't easily detect the driver type
-	// so we default to sqlite3. In practice, this constructor is used
-	// within an existing context that already has the driver detected.
+	// Detect driver via dialect-specific queries on the transaction.
 	return &EnhancedDbContext{
 		tx:            tx,
 		ChangeTracker: NewChangeTracker(),
-		driver:        "sqlite3", // default, should be set by parent context
+		driver:        detectTxDriver(tx),
 	}
+}
+
+// SetDriver overrides the detected driver (useful for tests or custom drivers).
+func (ctx *EnhancedDbContext) SetDriver(driver string) {
+	ctx.driver = driver
+}
+
+func (ctx *EnhancedDbContext) execContext(opCtx context.Context, query string, args ...any) (sql.Result, error) {
+	if ctx.tx != nil {
+		return ctx.tx.ExecContext(opCtx, query, args...)
+	}
+	return ctx.db.ExecContext(opCtx, query, args...)
+}
+
+func (ctx *EnhancedDbContext) queryRowContext(opCtx context.Context, query string, args ...any) *sql.Row {
+	if ctx.tx != nil {
+		return ctx.tx.QueryRowContext(opCtx, query, args...)
+	}
+	return ctx.db.QueryRowContext(opCtx, query, args...)
 }
 
 // Add marks an entity for insertion
@@ -200,12 +263,17 @@ func (ctx *EnhancedDbContext) Delete(entity interface{}) {
 
 // SaveChanges persists all pending changes to the database
 func (ctx *EnhancedDbContext) SaveChanges() (int, error) {
+	return ctx.SaveChangesContext(context.Background())
+}
+
+// SaveChangesContext persists all pending changes to the database using the provided context.
+func (ctx *EnhancedDbContext) SaveChangesContext(opCtx context.Context) (int, error) {
 	affected := 0
 
 	for entity, state := range ctx.ChangeTracker.entities {
 		switch state {
 		case EntityStateAdded:
-			err := ctx.insertEntity(entity)
+			err := ctx.insertEntityContext(opCtx, entity)
 			if err != nil {
 				return affected, err
 			}
@@ -213,7 +281,7 @@ func (ctx *EnhancedDbContext) SaveChanges() (int, error) {
 			affected++
 
 		case EntityStateModified:
-			err := ctx.updateEntity(entity)
+			err := ctx.updateEntityContext(opCtx, entity)
 			if err != nil {
 				return affected, err
 			}
@@ -221,7 +289,7 @@ func (ctx *EnhancedDbContext) SaveChanges() (int, error) {
 			affected++
 
 		case EntityStateDeleted:
-			err := ctx.deleteEntity(entity)
+			err := ctx.deleteEntityContext(opCtx, entity)
 			if err != nil {
 				return affected, err
 			}
@@ -235,6 +303,10 @@ func (ctx *EnhancedDbContext) SaveChanges() (int, error) {
 
 // insertEntity inserts a new entity into the database
 func (ctx *EnhancedDbContext) insertEntity(entity interface{}) error {
+	return ctx.insertEntityContext(context.Background(), entity)
+}
+
+func (ctx *EnhancedDbContext) insertEntityContext(opCtx context.Context, entity interface{}) error {
 	// Set timestamps before inserting
 	setTimestamps(entity, true) // true = create timestamps
 
@@ -252,11 +324,7 @@ func (ctx *EnhancedDbContext) insertEntity(entity interface{}) error {
 	if ctx.driver == driverPostgres {
 		queryWithReturning := query + " RETURNING id"
 		var id int64
-		if ctx.tx != nil {
-			err = ctx.tx.QueryRow(queryWithReturning, values...).Scan(&id)
-		} else {
-			err = ctx.db.QueryRow(queryWithReturning, values...).Scan(&id)
-		}
+		err = ctx.queryRowContext(opCtx, queryWithReturning, values...).Scan(&id)
 		if err != nil {
 			return err
 		}
@@ -267,12 +335,7 @@ func (ctx *EnhancedDbContext) insertEntity(entity interface{}) error {
 	}
 
 	// For SQLite/MySQL drivers, Exec and LastInsertId()
-	var result sql.Result
-	if ctx.tx != nil {
-		result, err = ctx.tx.Exec(query, values...)
-	} else {
-		result, err = ctx.db.Exec(query, values...)
-	}
+	result, err := ctx.execContext(opCtx, query, values...)
 	if err != nil {
 		return err
 	}
@@ -284,6 +347,10 @@ func (ctx *EnhancedDbContext) insertEntity(entity interface{}) error {
 
 // updateEntity updates an existing entity in the database
 func (ctx *EnhancedDbContext) updateEntity(entity interface{}) error {
+	return ctx.updateEntityContext(context.Background(), entity)
+}
+
+func (ctx *EnhancedDbContext) updateEntityContext(opCtx context.Context, entity interface{}) error {
 	// Set UpdatedAt timestamp before updating
 	setTimestamps(entity, false) // false = update timestamp only
 
@@ -304,16 +371,16 @@ func (ctx *EnhancedDbContext) updateEntity(entity interface{}) error {
 	// assign result of append back to same slice to satisfy linter and maintain behavior
 	values = append(values, idValue)
 
-	if ctx.tx != nil {
-		_, err := ctx.tx.Exec(query, values...)
-		return err
-	}
-	_, err := ctx.db.Exec(query, values...)
+	_, err := ctx.execContext(opCtx, query, values...)
 	return err
 }
 
 // deleteEntity removes an entity from the database
 func (ctx *EnhancedDbContext) deleteEntity(entity interface{}) error {
+	return ctx.deleteEntityContext(context.Background(), entity)
+}
+
+func (ctx *EnhancedDbContext) deleteEntityContext(opCtx context.Context, entity interface{}) error {
 	tableName := getTableName(entity)
 	idValue := getIDValue(entity)
 
@@ -324,22 +391,7 @@ func (ctx *EnhancedDbContext) deleteEntity(entity interface{}) error {
 	// Convert placeholders for PostgreSQL
 	query = convertQueryPlaceholders(query, ctx.driver)
 
-	// Debug output
-	fmt.Printf("DEBUG DELETE: tableName=%s, idValue=%v, query=%s\n", tableName, idValue, query)
-
-	if ctx.tx != nil {
-		result, err := ctx.tx.Exec(query, idValue)
-		if err == nil {
-			rowsAffected, _ := result.RowsAffected()
-			fmt.Printf("DEBUG DELETE TX: rowsAffected=%d\n", rowsAffected)
-		}
-		return err
-	}
-	result, err := ctx.db.Exec(query, idValue)
-	if err == nil {
-		rowsAffected, _ := result.RowsAffected()
-		fmt.Printf("DEBUG DELETE DB: rowsAffected=%d\n", rowsAffected)
-	}
+	_, err := ctx.execContext(opCtx, query, idValue)
 	return err
 }
 

--- a/orm/migrations/database_inspector.go
+++ b/orm/migrations/database_inspector.go
@@ -605,8 +605,6 @@ func (di *DatabaseInspector) parseIntValue(s string) int {
 func (di *DatabaseInspector) CompareWithModelSnapshot(dbSchema map[string]*TableSchema, modelSnapshots map[string]*ModelSnapshot) ([]MigrationChange, error) {
 	var changes []MigrationChange
 
-	fmt.Printf("DEBUG CompareWithModelSnapshot: dbSchema has %d tables, modelSnapshots has %d models\n", len(dbSchema), len(modelSnapshots))
-
 	// Track which tables exist in both database and models
 	processedTables := make(map[string]bool)
 
@@ -615,11 +613,8 @@ func (di *DatabaseInspector) CompareWithModelSnapshot(dbSchema map[string]*Table
 		tableName := snapshot.TableName
 		processedTables[tableName] = true
 
-		fmt.Printf("DEBUG: Processing model %s -> table %s\n", modelName, tableName)
-
 		if _, exists := dbSchema[tableName]; !exists {
 			// Table doesn't exist in database - create it
-			fmt.Printf("DEBUG: Table %s does not exist in database, creating CreateTable change\n", tableName)
 			changes = append(changes, MigrationChange{
 				Type:      CreateTable,
 				TableName: tableName,
@@ -628,7 +623,6 @@ func (di *DatabaseInspector) CompareWithModelSnapshot(dbSchema map[string]*Table
 			})
 		} else {
 			// Table exists - check for column changes
-			fmt.Printf("DEBUG: Table %s exists, checking for column changes\n", tableName)
 			columnChanges := di.compareTableColumns(dbSchema[tableName], snapshot)
 			changes = append(changes, columnChanges...)
 		}
@@ -637,23 +631,16 @@ func (di *DatabaseInspector) CompareWithModelSnapshot(dbSchema map[string]*Table
 	// Check for tables to drop (exist in database but not in models)
 	for tableName, tableSchema := range dbSchema {
 		if di.isSystemTable(tableName) {
-			fmt.Printf("DEBUG: Skipping system table %s\n", tableName)
 			continue
 		}
 
 		if !processedTables[tableName] {
-			fmt.Printf("DEBUG: Table %s exists in database but not in models, creating DropTable change\n", tableName)
 			changes = append(changes, MigrationChange{
 				Type:      DropTable,
 				TableName: tableName,
 				OldValue:  tableSchema,
 			})
 		}
-	}
-
-	fmt.Printf("DEBUG CompareWithModelSnapshot: Generated %d changes\n", len(changes))
-	for i, change := range changes {
-		fmt.Printf("DEBUG: Change %d: %s %s.%s\n", i, change.Type, change.TableName, change.ColumnName)
 	}
 
 	return changes, nil
@@ -672,7 +659,6 @@ func (di *DatabaseInspector) compareTableColumns(dbTable *TableSchema, modelSnap
 
 		if dbColumn, exists := dbTable.Columns[columnName]; !exists {
 			// Column doesn't exist in database - add it
-			fmt.Printf("DEBUG: Column %s.%s does not exist in database, creating AddColumn change\n", dbTable.Name, columnName)
 			changes = append(changes, MigrationChange{
 				Type:       AddColumn,
 				TableName:  dbTable.Name,
@@ -681,7 +667,6 @@ func (di *DatabaseInspector) compareTableColumns(dbTable *TableSchema, modelSnap
 			})
 		} else if di.hasColumnChanged(modelColumn, dbColumn) {
 			// Column exists - check if it has changed
-			fmt.Printf("DEBUG: Column %s.%s has changed, creating AlterColumn change\n", dbTable.Name, columnName)
 			changes = append(changes, MigrationChange{
 				Type:       AlterColumn,
 				TableName:  dbTable.Name,
@@ -695,7 +680,6 @@ func (di *DatabaseInspector) compareTableColumns(dbTable *TableSchema, modelSnap
 	// Check for columns to drop (exist in database but not in model)
 	for columnName, dbColumn := range dbTable.Columns {
 		if !processedColumns[columnName] {
-			fmt.Printf("DEBUG: Column %s.%s exists in database but not in model, creating DropColumn change\n", dbTable.Name, columnName)
 			changes = append(changes, MigrationChange{
 				Type:       DropColumn,
 				TableName:  dbTable.Name,
@@ -710,50 +694,33 @@ func (di *DatabaseInspector) compareTableColumns(dbTable *TableSchema, modelSnap
 
 // hasColumnChanged checks if a column definition has changed
 func (di *DatabaseInspector) hasColumnChanged(modelColumn *ColumnInfo, dbColumn *DatabaseColumnInfo) bool {
-	// Debug: Log column comparison
-	fmt.Printf("DEBUG: Comparing column %s:\n", dbColumn.Name)
-	fmt.Printf("DEBUG:   Model: DataType=%s, IsNullable=%t, DefaultValue=%v\n",
-		modelColumn.DataType, modelColumn.IsNullable, modelColumn.DefaultValue)
-	fmt.Printf("DEBUG:   DB: DataType=%s, IsNullable=%t, DefaultValue=%v\n",
-		dbColumn.DataType, dbColumn.IsNullable, dbColumn.DefaultValue)
-
 	// Compare data types (normalize for comparison)
 	if !di.isDataTypeCompatible(modelColumn.DataType, dbColumn.DataType) {
-		fmt.Printf("DEBUG:   -> Data type mismatch: %s vs %s\n", modelColumn.DataType, dbColumn.DataType)
 		return true
 	}
 
 	// Compare nullable
 	if modelColumn.IsNullable != dbColumn.IsNullable {
-		fmt.Printf("DEBUG:   -> Nullable mismatch: %t vs %t\n", modelColumn.IsNullable, dbColumn.IsNullable)
 		return true
 	}
 
 	// Compare default values
 	if (modelColumn.DefaultValue == nil) != (dbColumn.DefaultValue == nil) {
-		fmt.Printf("DEBUG:   -> Default value existence mismatch\n")
 		return true
 	}
 	if modelColumn.DefaultValue != nil && dbColumn.DefaultValue != nil &&
 		*modelColumn.DefaultValue != *dbColumn.DefaultValue {
-		fmt.Printf("DEBUG:   -> Default value content mismatch: %s vs %s\n",
-			*modelColumn.DefaultValue, *dbColumn.DefaultValue)
 		return true
 	}
 
 	// Compare length constraints
 	if (modelColumn.MaxLength == nil) != (dbColumn.MaxLength == nil) {
-		fmt.Printf("DEBUG:   -> Max length existence mismatch\n")
 		return true
 	}
 	if modelColumn.MaxLength != nil && dbColumn.MaxLength != nil &&
 		*modelColumn.MaxLength != *dbColumn.MaxLength {
-		fmt.Printf("DEBUG:   -> Max length value mismatch: %d vs %d\n",
-			*modelColumn.MaxLength, *dbColumn.MaxLength)
 		return true
 	}
-
-	fmt.Printf("DEBUG:   -> No changes detected\n")
 	return false
 }
 

--- a/orm/migrations/ef_migration_system.go
+++ b/orm/migrations/ef_migration_system.go
@@ -115,14 +115,18 @@ func NewEFMigrationManager(db *sql.DB, config *EFMigrationConfig) *EFMigrationMa
 
 // detectDatabaseDriver detects the database driver type
 func (em *EFMigrationManager) detectDatabaseDriver() DatabaseDriver {
+	// Use QueryRow to avoid leaking *sql.Rows.
+	var i int
+	var s string
+
 	// Test queries to detect database type
-	if _, err := em.db.Query("SELECT 1::integer"); err == nil {
+	if err := em.db.QueryRow("SELECT 1::integer").Scan(&i); err == nil {
 		return PostgreSQL
 	}
-	if _, err := em.db.Query("SELECT sqlite_version()"); err == nil {
+	if err := em.db.QueryRow("SELECT sqlite_version()").Scan(&s); err == nil {
 		return SQLite
 	}
-	if _, err := em.db.Query("SELECT VERSION()"); err == nil {
+	if err := em.db.QueryRow("SELECT VERSION()").Scan(&s); err == nil {
 		return MySQL
 	}
 	// Default to SQLite if detection fails
@@ -465,18 +469,14 @@ func (em *EFMigrationManager) applyMigration(migration Migration) error {
 
 	// Execute UP SQL with proper placeholder conversion
 	upSQL := em.convertQueryPlaceholders(migration.UpSQL)
-
-	// Debug: Log the SQL being executed
-	fmt.Printf("DEBUG: Executing SQL:\n%s\n", upSQL)
+	em.logger.Printf("Executing migration SQL: %s", migration.ID)
 
 	if _, err := tx.Exec(upSQL); err != nil {
 		// Record failed migration
 		em.recordMigrationResult(migration, MigrationStateFailed, 0, err.Error())
-		fmt.Printf("DEBUG: SQL execution failed: %v\n", err)
+		em.logger.Printf("Migration SQL failed: %s: %v", migration.ID, err)
 		return fmt.Errorf("failed to execute migration SQL: %w", err)
 	}
-
-	fmt.Printf("DEBUG: SQL executed successfully\n")
 
 	executionTime := int(time.Since(startTime).Milliseconds())
 


### PR DESCRIPTION
This PR hardens the ORM/dbcontext and migrations code for production use.

Changes:
- Add context-aware DB helpers and SaveChangesContext(ctx); keep SaveChanges() for backwards compatibility.
- Fix driver detection to avoid leaking *sql.Rows by using QueryRow().Scan(...).
- Detect driver in transaction contexts (no longer defaulting to sqlite).
- Remove noisy stdout debug prints from migrations schema comparison.

Validation:
- go test ./...
