### PR TITLE
ORM: context-aware query APIs for DbSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,10 @@ err = ctx.SaveChanges()
 
 ### Advanced Querying
 
+Security note: SQL fragments such as column names in `OrderBy(...)` (and any raw SQL snippets you pass as strings) must be trusted constants. Always pass user-supplied values via query parameters (the `?` args) rather than string concatenation.
+
+For timeouts/cancellation, prefer the context-aware query variants (e.g. `ToListContext(ctx)`, `FirstContext(ctx)`, `CountContext(ctx)`) when using `NewEnhancedDbSet[T](...)`.
+
 ```go
 userSet := dbcontext.EnhancedSet[models.User](ctx)
 

--- a/docs/guides/POSTGRESQL_SETUP_GUIDE.md
+++ b/docs/guides/POSTGRESQL_SETUP_GUIDE.md
@@ -88,6 +88,10 @@ func main() {
 }
 ```
 
+Security note: SQL fragments like `OrderBy("...")` (and any other string SQL snippets) must be trusted constants. Always pass user-supplied values via query parameters (`?` args), not string concatenation.
+
+Timeouts/cancellation: prefer the context-aware query variants (e.g. `ToListContext(ctx)`, `FirstOrDefaultContext(ctx)`, `CountContext(ctx)`) when you need deadlines or request-scoped cancellation.
+
 #### With Auto-Migration
 ```go
 import (

--- a/orm/dbcontext/db_context.go
+++ b/orm/dbcontext/db_context.go
@@ -4,6 +4,7 @@ package dbcontext
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -533,15 +534,26 @@ func (set *EnhancedDbSet[T]) AsNoTracking() *EnhancedDbSet[T] {
 
 // ToList executes the query and returns all results
 func (set *EnhancedDbSet[T]) ToList() ([]*T, error) {
+	return set.ToListContext(context.Background())
+}
+
+// ToListContext executes the query and returns all results using the provided context.
+func (set *EnhancedDbSet[T]) ToListContext(opCtx context.Context) ([]*T, error) {
+	if err := opCtx.Err(); err != nil {
+		return nil, err
+	}
+
 	query := set.buildQuery()
 
-	var rows *sql.Rows
-	var err error
+	var (
+		rows *sql.Rows
+		err  error
+	)
 
 	if set.ctx.tx != nil {
-		rows, err = set.ctx.tx.Query(query, set.whereArgs...)
+		rows, err = set.ctx.tx.QueryContext(opCtx, query, set.whereArgs...)
 	} else {
-		rows, err = set.ctx.db.Query(query, set.whereArgs...)
+		rows, err = set.ctx.db.QueryContext(opCtx, query, set.whereArgs...)
 	}
 
 	if err != nil {
@@ -569,12 +581,29 @@ func (set *EnhancedDbSet[T]) ToList() ([]*T, error) {
 		results = append(results, entity)
 	}
 
-	return results, rows.Err()
+	err = rows.Err()
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, err
+	}
+
+	return results, err
 }
 
 // FirstOrDefault returns the first result or nil if none found
 func (set *EnhancedDbSet[T]) FirstOrDefault() (*T, error) {
-	results, err := set.Take(1).ToList()
+	results, err := set.Take(1).ToListContext(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results[0], nil
+}
+
+// FirstOrDefaultContext returns the first result or nil if none found using the provided context.
+func (set *EnhancedDbSet[T]) FirstOrDefaultContext(opCtx context.Context) (*T, error) {
+	results, err := set.Take(1).ToListContext(opCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -586,6 +615,15 @@ func (set *EnhancedDbSet[T]) FirstOrDefault() (*T, error) {
 
 // Count returns the number of entities matching the query
 func (set *EnhancedDbSet[T]) Count() (int, error) {
+	return set.CountContext(context.Background())
+}
+
+// CountContext returns the number of entities matching the query using the provided context.
+func (set *EnhancedDbSet[T]) CountContext(opCtx context.Context) (int, error) {
+	if err := opCtx.Err(); err != nil {
+		return 0, err
+	}
+
 	// Safe: table name is trusted, user data is parameterized (see whereArgs...)
 	//nolint:gosec // G201: Identifiers are not user-controlled; all user data is parameterized.
 	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", set.tableName)
@@ -597,9 +635,9 @@ func (set *EnhancedDbSet[T]) Count() (int, error) {
 	var err error
 
 	if set.ctx.tx != nil {
-		err = set.ctx.tx.QueryRow(query, set.whereArgs...).Scan(&count)
+		err = set.ctx.tx.QueryRowContext(opCtx, query, set.whereArgs...).Scan(&count)
 	} else {
-		err = set.ctx.db.QueryRow(query, set.whereArgs...).Scan(&count)
+		err = set.ctx.db.QueryRowContext(opCtx, query, set.whereArgs...).Scan(&count)
 	}
 
 	return count, err
@@ -614,14 +652,40 @@ func (set *EnhancedDbSet[T]) Any() (bool, error) {
 	return count > 0, nil
 }
 
+// AnyContext checks if any records match the query using the provided context.
+func (set *EnhancedDbSet[T]) AnyContext(opCtx context.Context) (bool, error) {
+	count, err := set.CountContext(opCtx)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 // Find finds an entity by its primary key
 func (set *EnhancedDbSet[T]) Find(id interface{}) (*T, error) {
-	return set.Where("id = ?", id).FirstOrDefault()
+	return set.FindContext(context.Background(), id)
+}
+
+// FindContext finds an entity by its primary key using the provided context.
+func (set *EnhancedDbSet[T]) FindContext(opCtx context.Context, id interface{}) (*T, error) {
+	return set.Where("id = ?", id).FirstOrDefaultContext(opCtx)
 }
 
 // First returns the first result (errors if no results)
 func (set *EnhancedDbSet[T]) First() (*T, error) {
-	results, err := set.Take(1).ToList()
+	results, err := set.Take(1).ToListContext(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found")
+	}
+	return results[0], nil
+}
+
+// FirstContext returns the first result (errors if no results) using the provided context.
+func (set *EnhancedDbSet[T]) FirstContext(opCtx context.Context) (*T, error) {
+	results, err := set.Take(1).ToListContext(opCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +697,22 @@ func (set *EnhancedDbSet[T]) First() (*T, error) {
 
 // Single returns a single result (errors if 0 or >1 results)
 func (set *EnhancedDbSet[T]) Single() (*T, error) {
-	results, err := set.Take(2).ToList()
+	results, err := set.Take(2).ToListContext(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found")
+	}
+	if len(results) > 1 {
+		return nil, fmt.Errorf("multiple results found, expected single result")
+	}
+	return results[0], nil
+}
+
+// SingleContext returns a single result (errors if 0 or >1 results) using the provided context.
+func (set *EnhancedDbSet[T]) SingleContext(opCtx context.Context) (*T, error) {
+	results, err := set.Take(2).ToListContext(opCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/orm/dbcontext/db_set_context_test.go
+++ b/orm/dbcontext/db_set_context_test.go
@@ -1,0 +1,66 @@
+package dbcontext
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type ctxUser struct {
+	ID   int    `db:"id"`
+	Name string `db:"name"`
+}
+
+func (ctxUser) TableName() string { return "ctx_users" }
+
+func TestEnhancedDbSet_ToListContext_Canceled(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE ctx_users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO ctx_users(name) VALUES ('alice')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	ctx := NewEnhancedDbContextWithDB(db)
+	set := NewEnhancedDbSet[ctxUser](ctx)
+
+	opCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = set.ToListContext(opCtx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestEnhancedDbSet_CountContext_Canceled(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE ctx_users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	ctx := NewEnhancedDbContextWithDB(db)
+	set := NewEnhancedDbSet[ctxUser](ctx)
+
+	opCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = set.CountContext(opCtx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}


### PR DESCRIPTION
This is a follow-up (stacked) PR on top of #12.

Changes:
- Add context-aware query variants on EnhancedDbSet: ToListContext, FirstContext, FirstOrDefaultContext, SingleContext, FindContext, AnyContext, CountContext.
- Keep existing non-context methods as convenience wrappers using context.Background().
- Add unit tests for context cancellation behavior.
- Add docs warnings about trusted SQL fragments and point to the context-aware APIs.

Validation:
- go test ./...
