### PR TITLE
examples/basic: bump go version to 1.25

### DIFF
--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamboktulussimamora/gra/examples/basic
 
-go 1.24
+go 1.25
 
 replace github.com/lamboktulussimamora/gra => ../../
 


### PR DESCRIPTION
This keeps the nested examples/basic module aligned with the repo's Go 1.25 toolchain.

Change:
- Update `go` directive in `examples/basic/go.mod` from 1.24 to 1.25.
